### PR TITLE
Update home.js

### DIFF
--- a/home.js
+++ b/home.js
@@ -122,7 +122,6 @@ $(document).ready(function () {
                             '      <h5>' + boostSats + ' sats <small>from ' + boostSender + '</small></h5>' +
                             '      <span class="time_date" data-timestamp="' + dateTime + '">' + prettyDate(dateTime) + '</span>' +
                             '      <small class="podcast_episode">' + boostPodcast + ' - ' + boostEpisode + '</small>' +
-                            '      <br>' +
                             '      <hr>' +
                             '      <p>' + boostMessage + '</p>' +
                             '    </div>' +


### PR DESCRIPTION
Limit podcast episode titles to one line. A small change alongside patch-4 (which I'm not clever enough to know how to combine in the web version of Github).