### PR TITLE
Message template improvements

### DIFF
--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -168,10 +168,12 @@ $(document).ready(function () {
                             '      <h5 class="sats">' + boostSats + ' sats <small>' + boostSender + '</small></h5>' +
                             '      <time class="time_date" datetime="' + dateTime + '" title="' + dateFormat(dateTime) + '">' + prettyDate(dateTime) + '</time>' +
                             '      <small class="podcast_episode">' + boostPodcast + ' - ' + boostEpisode + '</small>' +
+                            '      <div class="msg_body">' +
                             boostMessage
-                        '    </div>' +
-                        '  </div>' +
-                        '</div>';
+                            '      </div>' +
+                            '    </div>' +
+                            '  </div>' +
+                            '</div>';
 
                         //Insert the message in the right spot
                         if (displayedMessageCount == 0) {

--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -164,7 +164,7 @@ $(document).ready(function () {
                             '<div class="outgoing_msg message" data-msgid="' + boostIndex + '">' +
                             '  <div class="sent_msg">' +
                             '    <div class="sent_withd_msg">' +
-                            '      <span class="app"><a href="' + appIconHref + '"><img src="' + appIconUrl + '" title="' + boostApp.toLowerCase() + '"></a></span>' +
+                            '      <span class="app"><a href="' + appIconHref + '"><img src="' + appIconUrl + '" title="' + boostApp + '" alt="' + boostApp + '"></a></span>' +
                             '      <h5 class="sats">' + boostSats + ' sats <small>' + boostSender + '</small></h5>' +
                             '      <time class="time_date" datetime="' + dateTime + '" title="' + dateFormat(dateTime) + '">' + prettyDate(dateTime) + '</time>' +
                             '      <small class="podcast_episode">' + boostPodcast + ' - ' + boostEpisode + '</small>' +


### PR DESCRIPTION
Restore proper boost app name casing on the img title attribute, and add the alt attribute to same. Also wrap the message body itself in its own div so that it isn't "free-floating" inside the overall message element.