### PR TITLE
Should pew when receiving our first boost

### DIFF
--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -56,6 +56,11 @@ $(document).ready(function () {
             scrollToTop = true;
         }
 
+        //Override shouldPew for receiving our first boost
+        if ($('div.nodata').length) {
+            shouldPew = true;
+        }
+
         //Build the endpoint url
         var url = '/api/v1/boosts?index=' + boostIndex;
         if (max > 0) {

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -56,6 +56,11 @@ $(document).ready(function () {
             scrollToTop = true;
         }
 
+        //Override shouldPew for receiving our first boost
+        if ($('div.nodata').length) {
+            shouldPew = true;
+        }
+
         //Build the endpoint url
         var url = '/api/v1/streams?index=' + boostIndex;
         if (max > 0) {


### PR DESCRIPTION
Fixes an issue with my previous PR in which there would be no pew pew during your first boost.

This is due to the code polling `initPage()` when no boosts exist on the page, which in turn calls `getIndex()` which then calls `getBoosts()` with `shouldPew=false` to generate the nodata message. I've added an override to set `shouldPew=true` when the nodata message is being shown to ensure proper pew pews when receiving the first boost.