### PR TITLE
Use tokio::time::sleep to sleep the LND poller and not the HTTP server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -598,6 +598,6 @@ async fn lnd_poller(server_config: Config, database_file_path: String) {
         current_index = dbif::get_last_boost_index_from_db(&db_filepath).unwrap();
         println!("Current index: {}", current_index);
 
-        std::thread::sleep(std::time::Duration::from_millis(9000));
+        tokio::time::sleep(tokio::time::Duration::from_millis(9000)).await;
     }
 }


### PR DESCRIPTION
The current `std::thread::sleep` call seems to also put the HTTP server to sleep after each iteration of the LND poller. I've updated the call to use `tokio::time::sleep` instead, which lets the HTTP server continue running while the LND poller is sleeping.

Resolves #47