### PR TITLE
Added navigation links and misc UI tweaks

### DIFF
--- a/webroot/html/home.html
+++ b/webroot/html/home.html
@@ -21,8 +21,17 @@
 
 <body>
 <div class="container">
-    <div class="titleHeader">
-        <div class="piIcon">
+    <div class="titleBar">
+        <h5 class="titleHeader">
+            Helipad<span class="titleSubtitle">: Boost Tracker</span>
+        </h5>
+        <ul class="navButtons">
+            <li class="active"><a href="/">Boosts</a></li>
+            <li><a href="/streams">Streams</a></li>
+        </ul>
+        <div class="rightHeader">
+            <div class="balanceDisplay">
+            </div>
             <span class="csv">
                 <a target="_blank" href="" title="Export as CSV">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
@@ -47,17 +56,13 @@
                 </svg>
             </a>
         </div>
-        <div class="balanceDisplay"></div>
-        <h5 class="titleHeader">Helipad<span class="titleSubtitle">: Boost Tracker</span></h5>
     </div>
     <div class="messaging">
         <div class="inbox_msg">
-
             <div class="mesgs">
                 <div class="msg_history"></div>
             </div>
         </div>
-        <div class="modeFooter"><a href="/streams">Streams</a></div>
         <div class="versionFooter"><a target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
     </div>
 </div>

--- a/webroot/html/streams.html
+++ b/webroot/html/streams.html
@@ -21,8 +21,17 @@
 
 <body>
 <div class="container">
-    <div class="titleHeader">
-        <div class="piIcon">
+    <div class="titleBar">
+        <h5 class="titleHeader">
+            Helipad<span class="titleSubtitle">: Boost Tracker</span>
+        </h5>
+        <ul class="navButtons">
+            <li><a href="/">Boosts</a></li>
+            <li class="active"><a href="/streams">Streams</a></li>
+        </ul>
+        <div class="rightHeader">
+            <div class="balanceDisplay">
+            </div>
             <span class="csv">
                 <a target="_blank" href="" title="Export as CSV">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
@@ -47,8 +56,6 @@
                 </svg>
             </a>
         </div>
-        <div class="balanceDisplay"></div>
-        <h5 class="titleHeader">Helipad<span class="titleSubtitle">: Boost Tracker</span></h5>
     </div>
     <div class="messaging">
         <div class="inbox_msg">
@@ -57,7 +64,6 @@
                 <div class="msg_history"></div>
             </div>
         </div>
-        <div class="modeFooter"><a href="/">Boosts</a></div>
         <div class="versionFooter"><a target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
     </div>
 </div>

--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -179,7 +179,7 @@ $(document).ready(function () {
                     //If there is a difference between actual and stated sats, display it
                     var boostDisplayAmount = boostSats + " sats";
                     if ((boostSats != boostActualSats) && boostSats > 0 && boostActualSats > 0) {
-                        boostDisplayAmount = boostActualSats + ' (<span title="Original amount before fees.">' + boostSats + '</span>)';
+                        boostDisplayAmount = '<span class="actual_sats" title="' + boostActualSats + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
                     }
 
                     if (!messageIds.includes(boostIndex) && element.action == 2) {

--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -177,9 +177,9 @@ $(document).ready(function () {
                     }
 
                     //If there is a difference between actual and stated sats, display it
-                    var boostDisplayAmount = boostSats + " sats";
+                    var boostDisplayAmount = numberFormat(boostSats) + " sats";
                     if ((boostSats != boostActualSats) && boostSats > 0 && boostActualSats > 0) {
-                        boostDisplayAmount = '<span class="actual_sats" title="' + boostActualSats + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
+                        boostDisplayAmount = '<span class="actual_sats" title="' + numberFormat(boostActualSats) + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
                     }
 
                     if (!messageIds.includes(boostIndex) && element.action == 2) {
@@ -292,7 +292,7 @@ $(document).ready(function () {
                     $('div.balanceDisplay').html('<span title="Error getting balance." class="error">Err</span>');
                 } else {
                     //Display the balance
-                    $('div.balanceDisplay').html('<span class="balanceLabel">Balance: </span>' + newBalance.toLocaleString("en-US"));
+                    $('div.balanceDisplay').html('<span class="balanceLabel">Balance: </span>' + numberFormat(newBalance));
 
                     //If the balance went up, do some fun stuff
                     if (newBalance > currentBalanceAmount && !init) {

--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -292,7 +292,7 @@ $(document).ready(function () {
                     $('div.balanceDisplay').html('<span title="Error getting balance." class="error">Err</span>');
                 } else {
                     //Display the balance
-                    $('div.balanceDisplay').html('Balance: <span>' + newBalance.toLocaleString("en-US") + '</span>');
+                    $('div.balanceDisplay').html('<span class="balanceLabel">Balance: </span>' + newBalance.toLocaleString("en-US"));
 
                     //If the balance went up, do some fun stuff
                     if (newBalance > currentBalanceAmount && !init) {

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -286,7 +286,7 @@ $(document).ready(function () {
                     $('div.balanceDisplay').html('<span title="Error getting balance." class="error">Err</span>');
                 } else {
                     //Display the balance
-                    $('div.balanceDisplay').html('Balance: <span>' + newBalance.toLocaleString("en-US") + '</span>');
+                    $('div.balanceDisplay').html('<span class="balanceLabel">Balance: </span>' + newBalance.toLocaleString("en-US"));
 
                     //If the balance went up, do some fun stuff
                     if (newBalance > currentBalanceAmount && !init) {

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -233,10 +233,10 @@ $(document).ready(function () {
                 //Show a message if still building
                 if ($('div.outgoing_msg').length == 0 && $('div.nodata').length == 0) {
                     inbox.prepend('<div class="nodata"><p>No data to show yet. Building the initial database may take some time if you have many ' +
-                        'transactions, or maybe you have not been sent any boostagrams yet?</p>' +
-                        '<p>This screen will automatically refresh as boostagrams are sent to you.</p>' +
-                        '<p><a href="https://podcastindex.org/apps">Check out a Podcasting 2.0 app to send boosts and boostagrams.</a></p>' +
-                        '<div class="lds-dual-ring"></div> Looking for boosts: <span class="invindex">' + currentInvoiceIndex + '</span>' +
+                        'transactions, or maybe you have not had any satoshis streamed to you yet?</p>' +
+                        '<p>This screen will automatically refresh as satoshis are streamed to you.</p>' +
+                        '<p><a href="https://podcastindex.org/apps">Check out a Podcasting 2.0 app to stream satoshis.</a></p>' +
+                        '<div class="lds-dual-ring"></div> Looking for streams: <span class="invindex">' + currentInvoiceIndex + '</span>' +
                         '</div>');
                 }
                 $('div.nodata span.invindex').text(currentInvoiceIndex);
@@ -257,7 +257,7 @@ $(document).ready(function () {
 
                 //Load more link
                 if ($('div.outgoing_msg').length > 0 && $('div.loadmore').length == 0 && (boostIndex > 1 || noIndex)) {
-                    inbox.append('<div class="loadmore"><a href="#">Show older boosts...</a></div>');
+                    inbox.append('<div class="loadmore"><a href="#">Show older streams...</a></div>');
                 }
             }
         });

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -173,7 +173,7 @@ $(document).ready(function () {
                     //If there is a difference between actual and stated sats, display it
                     var boostDisplayAmount = boostSats + " sats";
                     if ((boostSats != boostActualSats) && boostSats > 0 && boostActualSats > 0) {
-                        boostDisplayAmount = boostActualSats + ' (<span title="Original amount before fees.">' + boostSats + '</span>)';
+                        boostDisplayAmount = '<span class="actual_sats" title="' + boostActualSats + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
                     }
 
                     if (!messageIds.includes(boostIndex)) {

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -171,9 +171,9 @@ $(document).ready(function () {
                     }
 
                     //If there is a difference between actual and stated sats, display it
-                    var boostDisplayAmount = boostSats + " sats";
+                    var boostDisplayAmount = numberFormat(boostSats) + " sats";
                     if ((boostSats != boostActualSats) && boostSats > 0 && boostActualSats > 0) {
-                        boostDisplayAmount = '<span class="actual_sats" title="' + boostActualSats + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
+                        boostDisplayAmount = '<span class="actual_sats" title="' + numberFormat(boostActualSats) + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
                     }
 
                     if (!messageIds.includes(boostIndex)) {
@@ -286,7 +286,7 @@ $(document).ready(function () {
                     $('div.balanceDisplay').html('<span title="Error getting balance." class="error">Err</span>');
                 } else {
                     //Display the balance
-                    $('div.balanceDisplay').html('<span class="balanceLabel">Balance: </span>' + newBalance.toLocaleString("en-US"));
+                    $('div.balanceDisplay').html('<span class="balanceLabel">Balance: </span>' + numberFormat(newBalance));
 
                     //If the balance went up, do some fun stuff
                     if (newBalance > currentBalanceAmount && !init) {

--- a/webroot/script/utils.js
+++ b/webroot/script/utils.js
@@ -173,3 +173,8 @@ const closest = (arr, num) => {
         }
     }, Infinity) + num;
 }
+
+// Format a number according to the locale set in the browser
+const numberFormat = (num) => {
+    return new Intl.NumberFormat().format(num);
+}

--- a/webroot/style/default.css
+++ b/webroot/style/default.css
@@ -166,6 +166,10 @@ img {
     min-height: 81px;
 }
 
+.actual_sats:hover {
+    border-bottom: 1px dotted #666;
+}
+
 .time_date {
     text-align: right;
     color: black;

--- a/webroot/style/default.css
+++ b/webroot/style/default.css
@@ -252,11 +252,19 @@ img {
     height: 30px;
 }
 
+.titleBar {
+    display: flex;
+    align-items: baseline;
+    margin-top: 10px;
+    margin-bottom: 8px;
+}
+
 h5.titleHeader {
     color: floralwhite;
     display: inline;
     display: inline-block;
-    margin-top: 10px;
+    margin: 0;
+    margin-right: .5rem;
 }
 
 .msg_entry {
@@ -297,13 +305,12 @@ div.versionFooter {
     float: right;
 }
 div.balanceDisplay {
-    padding-top:8px;
     padding-right:8px;
     padding-left:8px;
-    float:right;
     color: floralwhite;
     -webkit-transition: background-color 2s;
             transition: background-color 2s;
+    text-align: right;
 }
 div.balanceDisplay span.good {
     colorcolor:greenyellow;
@@ -328,9 +335,41 @@ span.csv a {
 div.nodata span.invindex {
     color: orange;
 }
-div.modeFooter {
-    float:left;
+ul.navButtons {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    column-gap: 1rem;
+    margin: 0;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0;
+    font-size: 1.125rem;
 }
+ul.navButtons li {
+    border-bottom: 2px solid transparent;
+}
+ul.navButtons li:hover,
+ul.navButtons li.active {
+    border-bottom: 2px solid red
+}
+ul.navButtons li:hover a {
+    color: white;
+    text-decoration: none;
+}
+ul.navButtons li a {
+    color: #ccc;
+}
+ul.navButtons li.active a {
+    color: white;
+    font-weight: bold;
+}
+.rightHeader {
+    display: flex;
+    align-items: center;
+    justify-self: end;
+}
+
 /* https://loading.io/css/ */
 .lds-dual-ring {
     display: inline-block;
@@ -360,7 +399,16 @@ div.modeFooter {
 
 /* Small screens */
 @media only screen and (max-width: 550px) {
-    div.titleHeader .titleSubtitle {
+    h5, ul.navButtons {
+        font-size: 1rem;
+    }
+    .titleBar {
+        font-size: 0.875rem;
+    }
+    .balanceLabel {
+        display: none;
+    }
+    .titleSubtitle {
         display:none;
     }
     .time_date {


### PR DESCRIPTION
* Boosts and Streams links added to the top of the page to make it easy to switch between the two.
* Number formatting according to the browser's locale settings
* Actual sats received moved to mouse over
* Updated 'boosts' text to 'streams' on Streams page

Here's what the nav links, formatting, and mouse overs look like:
![image](https://github.com/Podcastindex-org/helipad/assets/16781/33efec2c-1029-46f1-93ff-78fe65a8746e)

Here's the iPhone SE mobile view (as rendered by Brave):
![image](https://github.com/Podcastindex-org/helipad/assets/16781/304929b3-2331-4721-9d19-355b2879d812)

Here's what the stream text looks like:
![image](https://github.com/Podcastindex-org/helipad/assets/16781/e8e03731-b1bb-4c9d-92ac-4de83b914714)
