### PR TITLE
Added numerology emojis to the interface

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -97,6 +97,16 @@ pub async fn apps_json(_ctx: Context) -> Response {
         .unwrap();
 }
 
+//Numerology definitions file
+pub async fn numerology_json(_ctx: Context) -> Response {
+    let file = fs::read("webroot/extra/numerology.json").expect("Something went wrong reading the file.");
+    return hyper::Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-type", "application/json; charset=utf-8")
+        .body(hyper::Body::from(file))
+        .unwrap();
+}
+
 //Serve a web asset by name from webroot subfolder according to it's requested type
 pub async fn asset(ctx: Context) -> Response {
     //Get query parameters

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,6 +262,7 @@ async fn main() {
     router.get("/pew.mp3", Box::new(handler::pewmp3));
     router.get("/favicon.ico", Box::new(handler::favicon));
     router.get("/apps.json", Box::new(handler::apps_json));
+    router.get("/numerology.json", Box::new(handler::numerology_json));
     //Assets
     router.get("/image", Box::new(handler::asset));
     router.get("/html", Box::new(handler::asset));

--- a/webroot/extra/numerology.json
+++ b/webroot/extra/numerology.json
@@ -1,0 +1,227 @@
+[
+    {
+        "name": "Satchel of Richards Donation x 7",
+        "emoji": "🍆🍆🍆🍆🍆🍆🍆",
+        "regex": "^1111111$"
+    },
+    {
+        "name": "Satchel of Richards Donation x 6",
+        "emoji": "🍆🍆🍆🍆🍆🍆",
+        "regex": "^111111$"
+    },
+    {
+        "name": "Satchel of Richards Donation x 5",
+        "emoji": "🍆🍆🍆🍆🍆",
+        "regex": "^11111$"
+    },
+    {
+        "name": "Satchel of Richards Donation x 4",
+        "emoji": "🍆🍆🍆🍆",
+        "regex": "^1111$"
+    },
+    {
+        "name": "Satchel of Richards Donation x 3",
+        "emoji": "🍆🍆🍆",
+        "regex": "^111$"
+    },
+    {
+        "name": "Satchel of Richards Donation x 2",
+        "emoji": "🍆🍆",
+        "regex": "^11$"
+    },
+    {
+        "name": "Ducks In a Row Donation x 7",
+        "emoji": "🦆🦆🦆🦆🦆🦆🦆",
+        "regex": "^2222222$"
+    },
+    {
+        "name": "Ducks In a Row Donation x 6",
+        "emoji": "🦆🦆🦆🦆🦆🦆",
+        "regex": "^222222$"
+    },
+    {
+        "name": "Ducks In a Row Donation x 5",
+        "emoji": "🦆🦆🦆🦆🦆",
+        "regex": "^22222$"
+    },
+    {
+        "name": "Ducks In a Row Donation x 4",
+        "emoji": "🦆🦆🦆🦆",
+        "regex": "^2222$"
+    },
+    {
+        "name": "Ducks In a Row Donation x 3",
+        "emoji": "🦆🦆🦆",
+        "regex": "^222$"
+    },
+    {
+        "name": "Ducks In a Row Donation x 2",
+        "emoji": "🦆🦆",
+        "regex": "^22$"
+    },
+    {
+        "name": "Countdown Donation x 5",
+        "emoji": "💥💥💥💥💥",
+        "regex": "7654321"
+    },
+    {
+        "name": "Countdown Donation x 4",
+        "emoji": "💥💥💥💥",
+        "regex": "654321"
+    },
+    {
+        "name": "Countdown Donation x 3",
+        "emoji": "💥💥💥",
+        "regex": "54321"
+    },
+    {
+        "name": "Countdown Donation x 2",
+        "emoji": "💥💥",
+        "regex": "4321"
+    },
+    {
+        "name": "Countdown Donation",
+        "emoji": "💥",
+        "regex": "321"
+    },
+    {
+        "name": "Countup Donation x 5",
+        "emoji": "🧛🧛🧛🧛🧛",
+        "regex": "1234567"
+    },
+    {
+        "name": "Countup Donation x 4",
+        "emoji": "🧛🧛🧛🧛",
+        "regex": "123456"
+    },
+    {
+        "name": "Countup Donation x 3",
+        "emoji": "🧛🧛🧛",
+        "regex": "12345"
+    },
+    {
+        "name": "Countup Donation x 2",
+        "emoji": "🧛🧛",
+        "regex": "1234"
+    },
+    {
+        "name": "Countup Donation",
+        "emoji": "🧛",
+        "regex": "123"
+    },
+    {
+        "name": "Bowler Donation x 3 +🦃",
+        "emoji": "🎳🎳🎳🦃",
+        "regex": "^101010$"
+    },
+    {
+        "name": "Bowler Donation x 2",
+        "emoji": "🎳🎳",
+        "regex": "^1010$"
+    },
+    {
+        "name": "Bowler Donation",
+        "emoji": "🎳",
+        "regex": "^10$"
+    },
+    {
+        "name": "Dice Donation",
+        "emoji": "🎲",
+        "regex": "11"
+    },
+    {
+        "name": "Bitcoin donation",
+        "emoji": "🪙",
+        "regex": "21"
+    },
+    {
+        "name": "Magic Number Donation",
+        "emoji": "✨",
+        "regex": "33"
+    },
+    {
+        "name": "Swasslenuff Donation",
+        "emoji": "💋",
+        "regex": "69"
+    },
+    {
+        "name": "Greetings Donation",
+        "emoji": "👋",
+        "regex": "73"
+    },
+    {
+        "name": "Love and Kisses Donation",
+        "emoji": "🥰",
+        "regex": "88"
+    },
+    {
+        "name": "Stoner Donation",
+        "emoji": "✌👽💨",
+        "regex": "420"
+    },
+    {
+        "name": "Devil Donation",
+        "emoji": "😈",
+        "regex": "666"
+    },
+    {
+        "name": "Angel Donation",
+        "emoji": "😇",
+        "regex": "777"
+    },
+    {
+        "name": "America Fuck Yeah Donation",
+        "emoji": "🇺🇸",
+        "regex": "1776"
+    },
+    {
+        "name": "Canada Donation",
+        "emoji": "🇨🇦",
+        "regex": "1867"
+    },
+    {
+        "name": "Boobs Donation",
+        "emoji": "🎱🎱",
+        "regex": "6006"
+    },
+    {
+        "name": "Boobs Donation",
+        "emoji": "🎱🎱",
+        "regex": "8008"
+    },
+    {
+        "name": "Wolf Donation",
+        "emoji": "🐺",
+        "regex": "9653"
+    },
+    {
+        "name": "Boost Donation",
+        "emoji": "🔁",
+        "regex": "30057"
+    },
+    {
+        "name": "Pi Donation x 5",
+        "emoji": "🥧🥧🥧🥧🥧",
+        "regex": "3141592"
+    },
+    {
+        "name": "Pi Donation x 4",
+        "emoji": "🥧🥧🥧🥧",
+        "regex": "314159"
+    },
+    {
+        "name": "Pi Donation x 3",
+        "emoji": "🥧🥧🥧",
+        "regex": "31415"
+    },
+    {
+        "name": "Pi Donation x 2",
+        "emoji": "🥧🥧",
+        "regex": "3141"
+    },
+    {
+        "name": "Pi Donation",
+        "emoji": "🥧",
+        "regex": "314"
+    }
+]

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -5,6 +5,7 @@ $(document).ready(function () {
     let pewAudioFile = '/pew.mp3';
     let pewAudio = new Audio(pewAudioFile);
     let appList = {};
+    let numerologyList = [];
     var connection = null;
     var messageIds = [];
     var currentInvoiceIndex = null;
@@ -110,8 +111,11 @@ $(document).ready(function () {
                     //If there is a difference between actual and stated sats, display it
                     var boostDisplayAmount = numberFormat(boostSats) + " sats";
                     if ((boostSats != boostActualSats) && boostSats > 0 && boostActualSats > 0) {
-                        boostDisplayAmount = '<span class="actual_sats" title="' + numberFormat(boostActualSats) + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
+                        boostDisplayAmount = '<span class="more_info" title="' + numberFormat(boostActualSats) + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
                     }
+
+                    //Determine the numerology behind the sat amount
+                    boostNumerology = gatherNumerology(boostSats);
 
                     if (!messageIds.includes(boostIndex)) {
                         let dateTime = new Date(element.time * 1000).toISOString();
@@ -123,7 +127,7 @@ $(document).ready(function () {
                             '  <div class="sent_msg">' +
                             '    <div class="sent_withd_msg">' +
                             '      <span class="app"><a href="' + appIconHref + '"><img src="' + appIconUrl + '" title="' + boostApp + '" alt="' + boostApp + '"></a></span>' +
-                            '      <h5 class="sats">' + boostDisplayAmount + ' ' + boostSender + '</small></h5>' +
+                            '      <h5 class="sats">' + boostDisplayAmount + ' ' + boostSender + ' ' + boostNumerology + '</small></h5>' +
                             '      <time class="time_date" datetime="' + dateTime + '" title="' + dateFormat(dateTime) + '">' + prettyDate(dateTime) + '</time>' +
                             '      <small class="podcast_episode">' + boostPodcast + ' - ' + boostEpisode + '</small>' +
                             boostMessage
@@ -198,6 +202,34 @@ $(document).ready(function () {
                 }
             }
         });
+    }
+
+    //Determine any meaning behind this sat value
+    //(uses boostbot numerology by default: https://github.com/valcanobacon/BoostBots)
+    function gatherNumerology(value) {
+        let numerology = value.toString();
+        let meaning = [];
+
+        // replace numerology with emojis
+        numerologyList.forEach(item => {
+            newNumerology = numerology.replaceAll(new RegExp(item.regex, 'g'), item.emoji);
+
+            if (newNumerology != numerology) {
+                meaning.push(item.name);
+            }
+
+            numerology = newNumerology;
+        });
+
+        // remove unmatched numbers
+        numerology = numerology.replaceAll(new RegExp('[0-9]+', 'g'), '');
+
+        // show meaning in mouse hover
+        if (meaning) {
+            numerology = '<span class="more_info" title="' + meaning.join(', ') + '">' + numerology + '</span>';
+        }
+
+        return numerology;
     }
 
     //Animate some confetti on the page with a given duration interval in milliseconds
@@ -282,11 +314,24 @@ $(document).ready(function () {
         return appList;
     }
 
+    //Get the defined numerology
+    async function getNumerologyList() {
+        numerologyList = await $.ajax({
+            url: "/numerology.json",
+            type: "GET",
+            contentType: "application/json; charset=utf-8",
+            dataType: "json"
+        });
+
+        return numerologyList;
+    }
+
     //Build the UI with the page loads
     async function initPage() {
         //Get starting balance and index number
         getBalance(true);
         await getAppList();
+        await getNumerologyList();
         getIndex();
     }
 

--- a/webroot/style/default.css
+++ b/webroot/style/default.css
@@ -166,7 +166,7 @@ img {
     min-height: 81px;
 }
 
-.actual_sats:hover {
+.more_info:hover {
     border-bottom: 1px dotted #666;
 }
 


### PR DESCRIPTION
This adds emojis for donation amounts with known numerology. The numerology itself is defined in a `numerology.json` file that could _theoretically_ be changed manually by whoever is running Helipad.

It uses BoostBot's numerology by default: https://github.com/valcanobacon/BoostBots . I know that some shows have developed their own numerology (Podnews: https://podnews.net/article/boostagram-numerology) and I wonder if I need to add a configuration page to allow the user to change or remove these numbers before this change gets deployed.

Here is what the interface looks like with this change:
![image](https://github.com/Podcastindex-org/helipad/assets/16781/6cf150a6-9f21-46f0-80e7-e980987446d6)
