### PR TITLE
Resolve remote items into podcast/episode names and show with boosts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ voca_rs = "1.14.0"
 configure_me = "0.4.0"
 handlebars = "4.2.1"
 chrono = "0.4.19"
+reqwest = "0.11.20"
+lru = "0.11.1"
 
 [build-dependencies]
 configure_me_codegen = "0.4.1"

--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -90,6 +90,8 @@ $(document).ready(function () {
                     let boostApp = element.app;
                     let boostPodcast = element.podcast;
                     let boostEpisode = element.episode;
+                    let boostRemotePodcast = element.remote_podcast;
+                    let boostRemoteEpisode = element.remote_episode;
 
                     //Icon
                     let appIcon = appList[boostApp.toLowerCase()] || {};
@@ -129,7 +131,10 @@ $(document).ready(function () {
                             '      <span class="app"><a href="' + appIconHref + '"><img src="' + appIconUrl + '" title="' + boostApp + '" alt="' + boostApp + '"></a></span>' +
                             '      <h5 class="sats">' + boostDisplayAmount + ' ' + boostSender + ' ' + boostNumerology + '</small></h5>' +
                             '      <time class="time_date" datetime="' + dateTime + '" title="' + dateFormat(dateTime) + '">' + prettyDate(dateTime) + '</time>' +
-                            '      <small class="podcast_episode">' + boostPodcast + ' - ' + boostEpisode + '</small>' +
+                            '      <small class="podcast_episode">' +
+                            '        ' + boostPodcast + ' - ' + boostEpisode +
+                            '        <span class="remote_item">' + (boostRemoteEpisode ? '(' + boostRemotePodcast + ' - ' + boostRemoteEpisode + ')' : '') + '</span>' +
+                            '      </small>' +
                             boostMessage
                         '    </div>' +
                         '  </div>' +

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -90,6 +90,8 @@ $(document).ready(function () {
                     let boostApp = element.app;
                     let boostPodcast = element.podcast;
                     let boostEpisode = element.episode;
+                    let boostRemotePodcast = element.remote_podcast;
+                    let boostRemoteEpisode = element.remote_episode;
 
                     //Icon
                     let appIcon = appList[boostApp.toLowerCase()] || {};
@@ -129,7 +131,10 @@ $(document).ready(function () {
                             '      <span class="app"><a href="' + appIconHref + '"><img src="' + appIconUrl + '" title="' + boostApp + '" alt="' + boostApp + '"></a></span>' +
                             '      <h5 class="sats">' + boostDisplayAmount + ' ' + boostSender + ' ' + boostNumerology + '</small></h5>' +
                             '      <time class="time_date" datetime="' + dateTime + '" title="' + dateFormat(dateTime) + '">' + prettyDate(dateTime) + '</time>' +
-                            '      <small class="podcast_episode">' + boostPodcast + ' - ' + boostEpisode + '</small>' +
+                            '      <small class="podcast_episode">' +
+                            '        ' + boostPodcast + ' - ' + boostEpisode +
+                            '        <span class="remote_item">' + (boostRemoteEpisode ? '(' + boostRemotePodcast + ' - ' + boostRemoteEpisode + ')' : '') + '</span>' +
+                            '      </small>' +
                             boostMessage
                         '    </div>' +
                         '  </div>' +


### PR DESCRIPTION
Uses the Podcastindex API to resolve remote item guids into actual podcast (feedTitle) and episode (title) names, show the names in parentheses in the interface, and store them in the Helipad DB.

![image](https://github.com/Podcastindex-org/helipad/assets/16781/93fe706d-473e-43ce-a904-e43116853f74)

![image](https://github.com/Podcastindex-org/helipad/assets/16781/8134d0d3-03aa-4a11-9fec-9c1483c637ae)

I did notice that the feedTitle and title seem to be the same for most music tracks:
* https://api.podcastindex.org/api/1.0/value/byepisodeguid?podcastguid=b8b6971e-403e-568f-a4e6-7aa2b45e50d4&episodeguid=72a3b402-8491-4cd9-823e-a621fd81b86f
* https://api.podcastindex.org/api/1.0/value/byepisodeguid?podcastguid=78ae7a58-679a-50dd-95c0-c8f69e431b78&episodeguid=e1c2e15d-656c-41de-a52c-6771292a7312