### PR TITLE
Added GitHub Action to build and deploy Docker images to DockerHub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,56 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=semver,pattern={{version}},value=${{ inputs.version }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+          type=semver,pattern={{major}},value=${{ inputs.version }}
+          type=raw,value=latest,enable={{is_default_branch}}
+        flavor: |
+          latest=false
+
+    - name: Build and Push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+###
+##: Set up native compile
+###
+FROM rust:bookworm AS build-native
+RUN apt-get update && apt-get install -y ca-certificates openssl sqlite3
+RUN echo $(arch)-unknown-linux-gnu > /tmp/rust-target
+
+###
+##: Set up arm64 cross compile
+###
+FROM --platform=$BUILDPLATFORM rust:bookworm AS build-cross-arm64
+
+ARG CC=aarch64-linux-gnu-gcc
+ARG CXX=aarch64-linux-gnu-g++
+ARG PKG_CONFIG_SYSROOT_DIR=/usr/lib/aarch64-linux-gnu/
+ARG CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+RUN dpkg --add-architecture arm64
+RUN apt-get update
+RUN apt-get install -y g++-aarch64-linux-gnu
+RUN apt-get install -y libsqlite3-dev:arm64 libssl-dev:arm64
+
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN echo aarch64-unknown-linux-gnu > /tmp/rust-target
+
+###
+##: Build targets
+###
+FROM build-native AS build-arm64-on-arm64
+FROM build-native AS build-amd64-on-amd64
+FROM build-cross-arm64 AS build-arm64-on-amd64
+
+#####
+
+###
+##: Build stage
+###
+FROM build-$TARGETARCH-on-$BUILDARCH as builder
+
+WORKDIR /opt/helipad
+
+COPY . /opt/helipad
+RUN cargo build --release --target=$(cat /tmp/rust-target)
+RUN cp ./target/$(cat /tmp/rust-target)/release/helipad .
+
+###
+##: Bundle stage
+###
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim AS runner
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates openssl sqlite3 && \
+    rm -fr /var/lib/apt/lists/*
+
+WORKDIR /opt/helipad
+
+COPY --from=builder /opt/helipad/helipad .
+COPY --from=builder /opt/helipad/webroot ./webroot
+COPY --from=builder /opt/helipad/helipad.conf .
+
+RUN useradd -u 1000 helipad
+RUN mkdir /data && chown -R 1000:1000 /data
+
+USER helipad
+
+EXPOSE 2112/tcp
+
+ENTRYPOINT ["/opt/helipad/helipad"]


### PR DESCRIPTION
# Changes
* Added Dockerfile to compile amd64 and cross-compile arm64 Docker images
* Added GitHub Action to automatically build and push images to Docker Hub on pushes to the repo:
  * The `latest` image is updated with every push to `main`
  * Version tagged images (e.g. `v0.1.10`) are added/updated with every push of a version tag
  * Image builds can be manually-triggered by clicking on the `Run Workflow` button in the Actions tab

# Docker Hub and GitHub setup:

* Create an access token in Docker Hub (Account Settings -> Security -> New Access Token -> Read/Write):
  ![image](https://github.com/Podcastindex-org/helipad/assets/16781/df186277-28b4-4884-bc99-cfa066503852)

* Add the `podcastindexorg` username and generated access token to repository secrets (Settings -> Actions -> New repository secret)
  ![image](https://github.com/Podcastindex-org/helipad/assets/16781/6de4419c-ef12-4744-9216-eb50f59cdcfe)

* Add the `IMAGE_NAME` (i.e. `podcastindexorg/podcasting20-helipad`) variable to repository variables (Settings -> Actions -> Variables -> New repository variable):
  ![image](https://github.com/Podcastindex-org/helipad/assets/16781/9a3e3f4f-800e-4388-bcb4-b562f6e9af20)
