### PR TITLE
Link remote podcast/episodes to PI website and include in CSV

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -528,7 +528,7 @@ pub async fn csv_export_boosts(_ctx: Context) -> Response {
             let mut csv = String::new();
 
             //CSV column name header
-            csv.push_str(format!("count, index, time, value_msat, value_sat, value_msat_total, value_sat_total, action, sender, app, message, podcast, episode\n").as_str());
+            csv.push_str(format!("count,index,time,value_msat,value_sat,value_msat_total,value_sat_total,action,sender,app,message,podcast,episode,remote_podcast,remote_episode\n").as_str());
 
             //Iterate the boost set
             let mut count: u64 = 1;
@@ -550,7 +550,7 @@ pub async fn csv_export_boosts(_ctx: Context) -> Response {
                 //The main export data formatting
                 csv.push_str(
                     format!(
-                        "{},{},\"{}\",{},{},{},{},{},\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"\n",
+                        "{},{},\"{}\",{},{},{},{},{},\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"\n",
                         count,
                         boost.index,
                         boost_time,
@@ -563,7 +563,9 @@ pub async fn csv_export_boosts(_ctx: Context) -> Response {
                         BoostRecord::escape_for_csv(boost.app),
                         BoostRecord::escape_for_csv(boost.message),
                         BoostRecord::escape_for_csv(boost.podcast),
-                        BoostRecord::escape_for_csv(boost.episode)
+                        BoostRecord::escape_for_csv(boost.episode),
+                        BoostRecord::escape_for_csv(boost.remote_podcast.unwrap_or("".to_string())),
+                        BoostRecord::escape_for_csv(boost.remote_episode.unwrap_or("".to_string()))
                     ).as_str()
                 );
 

--- a/webroot/script/home.js
+++ b/webroot/script/home.js
@@ -92,6 +92,12 @@ $(document).ready(function () {
                     let boostEpisode = element.episode;
                     let boostRemotePodcast = element.remote_podcast;
                     let boostRemoteEpisode = element.remote_episode;
+                    let boostTlv = null;
+
+                    try {
+                        boostTlv = JSON.parse(element.tlv)
+                    }
+                    catch {}
 
                     //Icon
                     let appIcon = appList[boostApp.toLowerCase()] || {};
@@ -119,6 +125,19 @@ $(document).ready(function () {
                     //Determine the numerology behind the sat amount
                     boostNumerology = gatherNumerology(boostSats);
 
+                    //Generate remote item and link to podcastindex website if one exists
+                    let boostRemoteInfo = '';
+                    if (boostRemoteEpisode) {
+                        boostRemoteInfo = '(' + boostRemotePodcast + ' - ' + boostRemoteEpisode + ')';
+
+                        if (boostTlv && boostTlv.remote_feed_guid) {
+                            boostRemoteInfo = `
+                            <a href="https://podcastindex.org/podcast/${boostTlv.remote_feed_guid}" target="_blank" style="color: blue;">
+                                ${boostRemoteInfo}
+                            </a>`;
+                        }
+                    }
+
                     if (!messageIds.includes(boostIndex) && element.action == 2) {
                         let dateTime = new Date(element.time * 1000).toISOString();
                         $('div.nodata').remove();
@@ -135,7 +154,7 @@ $(document).ready(function () {
                             '      </time>' +
                             '      <small class="podcast_episode">' +
                             '        ' + boostPodcast + ' - ' + boostEpisode +
-                            '        <span class="remote_item">' + (boostRemoteEpisode ? '(' + boostRemotePodcast + ' - ' + boostRemoteEpisode + ')' : '') + '</span>' +
+                            '        <span class="remote_item">' + boostRemoteInfo + '</span>' +
                             '      </small>' +
                             boostMessage
                         '    </div>' +

--- a/webroot/script/streams.js
+++ b/webroot/script/streams.js
@@ -92,6 +92,12 @@ $(document).ready(function () {
                     let boostEpisode = element.episode;
                     let boostRemotePodcast = element.remote_podcast;
                     let boostRemoteEpisode = element.remote_episode;
+                    let boostTlv = null;
+
+                    try {
+                        boostTlv = JSON.parse(element.tlv)
+                    }
+                    catch {}
 
                     //Icon
                     let appIcon = appList[boostApp.toLowerCase()] || {};
@@ -119,6 +125,19 @@ $(document).ready(function () {
                     //Determine the numerology behind the sat amount
                     boostNumerology = gatherNumerology(boostSats);
 
+                    //Generate remote item and link to podcastindex website if one exists
+                    let boostRemoteInfo = '';
+                    if (boostRemoteEpisode) {
+                        boostRemoteInfo = '(' + boostRemotePodcast + ' - ' + boostRemoteEpisode + ')';
+
+                        if (boostTlv && boostTlv.remote_feed_guid) {
+                            boostRemoteInfo = `
+                            <a href="https://podcastindex.org/podcast/${boostTlv.remote_feed_guid}" target="_blank" style="color: blue;">
+                                ${boostRemoteInfo}
+                            </a>`;
+                        }
+                    }
+
                     if (!messageIds.includes(boostIndex)) {
                         let dateTime = new Date(element.time * 1000).toISOString();
                         $('div.nodata').remove();
@@ -135,7 +154,7 @@ $(document).ready(function () {
                             '      </time>' +
                             '      <small class="podcast_episode">' +
                             '        ' + boostPodcast + ' - ' + boostEpisode +
-                            '        <span class="remote_item">' + (boostRemoteEpisode ? '(' + boostRemotePodcast + ' - ' + boostRemoteEpisode + ')' : '') + '</span>' +
+                            '        <span class="remote_item">' + boostRemoteInfo + '</span>' +
                             '      </small>' +
                             boostMessage
                         '    </div>' +


### PR DESCRIPTION
* Adds links for remote podcast/episode boosts that link to  corresponding podcast pages on podcastindex.org.
  ![image](https://github.com/Podcastindex-org/helipad/assets/16781/984d17d3-1cad-4f0a-bf8c-9d4a8a442fb6) 
 Links to https://podcastindex.org/podcast/b8b6971e-403e-568f-a4e6-7aa2b45e50d4
* Adds `remote_podcast` and `remote_episode` fields to the CSV export
* Removes leading spaces from column names in CSV export