### PR TITLE
Show automated boosts in the Boosts tab

### DIFF
--- a/dbif/src/lib.rs
+++ b/dbif/src/lib.rs
@@ -289,6 +289,7 @@ pub fn get_boosts_from_db(filepath: &String, index: u64, max: u64, direction: bo
         ltgt = "<=";
     }
 
+    //Query for boosts and automated boosts
     let sqltxt = format!("SELECT idx, \
                                        time, \
                                        value_msat, \
@@ -304,7 +305,7 @@ pub fn get_boosts_from_db(filepath: &String, index: u64, max: u64, direction: bo
                                        remote_episode, \
                                        reply_sent \
                                  FROM boosts \
-                                 WHERE action = 2 \
+                                 WHERE action IN (2, 4) \
                                    AND idx {} :index \
                                  ORDER BY idx DESC \
                                  LIMIT :max", ltgt);

--- a/src/lightning.rs
+++ b/src/lightning.rs
@@ -330,8 +330,9 @@ pub async fn parse_podcast_tlv(boost: &mut dbif::BoostRecord, val: &Vec<u8>, rem
             if rawboost.action.is_some() {
                 boost.action = match rawboost.action.unwrap().as_str() {
                     "stream" => 1, //This indicates a per-minute podcast payment
-                    "boost" => 2,  //This is a manual boost or boost-a-gram
-                    _ => 3,
+                    "boost"  => 2, //This is a manual boost or boost-a-gram
+                    "auto"   => 4, //This is an automated boost
+                    _        => 3, //Invalid or no action (set to 3 for legacy reasons)
                 }
             }
 

--- a/webroot/script/helipad.js
+++ b/webroot/script/helipad.js
@@ -145,6 +145,18 @@ $(document).ready(function () {
                         boostDisplayAmount = '<span class="more_info" title="' + numberFormat(boostActualSats) + ' sats received after splits/fees.">' + boostDisplayAmount + '</span>';
                     }
 
+                    //Show clock icon for automated boosts
+                    if (boostTlv && boostTlv.action == "auto") {
+                        boostDisplayAmount = `
+                        <span title="Automated boost">
+                          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-clock" viewBox="0 0 16 16" style="vertical-align: bottom;">
+                            <path d="M8.515 1.019A7 7 0 0 0 8 1V0a8 8 0 0 1 .589.022l-.074.997zm2.004.45a7.003 7.003 0 0 0-.985-.299l.219-.976c.383.086.76.2 1.126.342l-.36.933zm1.37.71a7.01 7.01 0 0 0-.439-.27l.493-.87a8.025 8.025 0 0 1 .979.654l-.615.789a6.996 6.996 0 0 0-.418-.302zm1.834 1.79a6.99 6.99 0 0 0-.653-.796l.724-.69c.27.285.52.59.747.91l-.818.576zm.744 1.352a7.08 7.08 0 0 0-.214-.468l.893-.45a7.976 7.976 0 0 1 .45 1.088l-.95.313a7.023 7.023 0 0 0-.179-.483zm.53 2.507a6.991 6.991 0 0 0-.1-1.025l.985-.17c.067.386.106.778.116 1.17l-1 .025zm-.131 1.538c.033-.17.06-.339.081-.51l.993.123a7.957 7.957 0 0 1-.23 1.155l-.964-.267c.046-.165.086-.332.12-.501zm-.952 2.379c.184-.29.346-.594.486-.908l.914.405c-.16.36-.345.706-.555 1.038l-.845-.535zm-.964 1.205c.122-.122.239-.248.35-.378l.758.653a8.073 8.073 0 0 1-.401.432l-.707-.707z"/>
+                            <path d="M8 1a7 7 0 1 0 4.95 11.95l.707.707A8.001 8.001 0 1 1 8 0v1z"/>
+                            <path d="M7.5 3a.5.5 0 0 1 .5.5v5.21l3.248 1.856a.5.5 0 0 1-.496.868l-3.5-2A.5.5 0 0 1 7 9V3.5a.5.5 0 0 1 .5-.5z"/>
+                          </svg>
+                        </span>` + boostDisplayAmount;
+                    }
+
                     //Determine the numerology behind the sat amount
                     boostNumerology = gatherNumerology(boostSats);
 


### PR DESCRIPTION
Shows a clock icon next to automated boosts. No action boosts are shown with whatever information is available:

![image](https://github.com/Podcastindex-org/helipad/assets/16781/9fd91f91-3a23-4721-bc3d-b254949a5ba0)


Resolves #67 #71 