### PR TITLE
Added browser-based reply boosts (e.g. WebLN, Alby)

### DIFF
--- a/webroot/html/home.html
+++ b/webroot/html/home.html
@@ -64,7 +64,7 @@
                 <div class="msg_history"></div>
             </div>
         </div>
-        <div class="versionFooter"><a target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
+        <div class="versionFooter"><a id="helipad-version" target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
     </div>
 </div>
 </body>

--- a/webroot/html/sent.html
+++ b/webroot/html/sent.html
@@ -64,7 +64,7 @@
                 <div class="msg_history"></div>
             </div>
         </div>
-        <div class="versionFooter"><a target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
+        <div class="versionFooter"><a id="helipad-version" target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
     </div>
 </div>
 </body>

--- a/webroot/html/streams.html
+++ b/webroot/html/streams.html
@@ -65,7 +65,7 @@
                 <div class="msg_history"></div>
             </div>
         </div>
-        <div class="versionFooter"><a target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
+        <div class="versionFooter"><a id="helipad-version" target="_blank" href="https://github.com/Podcastindex-org/helipad">v{{version}}</a></div>
     </div>
 </div>
 </body>

--- a/webroot/script/utils.js
+++ b/webroot/script/utils.js
@@ -186,3 +186,30 @@ const ucWords = (text) => {
         return word.substr(0, 1).toUpperCase() + word.substr(1);
     }).join(" ");
 }
+
+// Resolve a keysend address (e.g. somebody@getalby.com) into a pubkey and custom key/value
+const resolveKeysendAddress = async (address) => {
+    if (!address.match(/^[A-Za-z0-9-_+\.]+\@[A-Za-z0-9-_+\.]+$/)) {
+        return; // not a keysend address
+    }
+
+    const [username, hostname] = address.split('@');
+    let keysendInfo;
+
+    try {
+        keysendInfo = await $.get(`https://${hostname}/.well-known/keysend/${username}`);
+    }
+    catch (err) {
+        if (err.status == 404) {
+            throw new Error(`Keysend address does not exist: ${address}`);
+        }
+
+        throw new Error(`Error connecting to server to lookup keysend address`);
+    }
+
+    if (keysendInfo.status == 'ERROR') {
+        throw new Error(`Error resolving keysend address ${address}: ${keysendInfo.reason}`);
+    }
+
+    return keysendInfo;
+}


### PR DESCRIPTION
Adds an additional option to the reply boost modal to select between Node and Browser (if a WebLN extension is installed). If Browser is selected, it enables the WebLN extension and sends the boost through it instead of the node.

Resolves #76