### PR TITLE
Improve strange TLV handling

### DIFF
--- a/dbif/src/lib.rs
+++ b/dbif/src/lib.rs
@@ -647,7 +647,7 @@ pub fn get_boosts_from_db(filepath: &String, index: u64, max: u64, direction: bo
 }
 
 
-//Get all of the boosts from the database
+//Get all of the non-boosts from the database
 pub fn get_streams_from_db(filepath: &String, index: u64, max: u64, direction: bool, escape_html: bool) -> Result<Vec<BoostRecord>, Box<dyn Error>> {
     let conn = connect_to_database(false, filepath)?;
     let mut boosts: Vec<BoostRecord> = Vec::new();
@@ -658,7 +658,7 @@ pub fn get_streams_from_db(filepath: &String, index: u64, max: u64, direction: b
         ltgt = "<=";
     }
 
-    //Build the query
+    //Build the query to include anything that's not a boost or auto boost
     let sqltxt = format!("SELECT idx, \
                                        time, \
                                        value_msat, \
@@ -674,7 +674,7 @@ pub fn get_streams_from_db(filepath: &String, index: u64, max: u64, direction: b
                                        remote_episode, \
                                        reply_sent \
                                  FROM boosts \
-                                 WHERE action = 1 \
+                                 WHERE action NOT IN (2, 4) \
                                    AND idx {} :index \
                                  ORDER BY idx DESC \
                                  LIMIT :max", ltgt);

--- a/src/lightning.rs
+++ b/src/lightning.rs
@@ -298,7 +298,7 @@ pub async fn parse_podcast_tlv(boost: &mut dbif::BoostRecord, val: &Vec<u8>, rem
                     "stream" => 1, //This indicates a per-minute podcast payment
                     "boost"  => 2, //This is a manual boost or boost-a-gram
                     "auto"   => 4, //This is an automated boost
-                    _        => 3, //Invalid or no action (set to 3 for legacy reasons)
+                    _        => 3, //Invalid action or empty string (set to 3 for legacy reasons)
                 }
             }
 

--- a/src/lightning.rs
+++ b/src/lightning.rs
@@ -26,47 +26,13 @@ pub struct RawBoost {
     #[serde(default = "d_blank")]
     app_name: Option<String>,
     #[serde(default = "d_blank")]
-    app_version: Option<String>,
-    #[serde(default = "d_blank")]
-    boost_link: Option<String>,
-    #[serde(default = "d_blank")]
     message: Option<String>,
-    #[serde(default = "d_blank")]
-    name: Option<String>,
-    #[serde(default = "d_blank")]
-    pubkey: Option<String>,
-    #[serde(default = "d_blank")]
-    sender_key: Option<String>,
     #[serde(default = "d_blank")]
     sender_name: Option<String>,
     #[serde(default = "d_blank")]
-    sender_id: Option<String>,
-    #[serde(default = "d_blank")]
-    sig_fields: Option<String>,
-    #[serde(default = "d_blank")]
-    signature: Option<String>,
-    #[serde(default = "d_blank")]
-    speed: Option<String>,
-    #[serde(default = "d_blank")]
-    uuid: Option<String>,
-    #[serde(default = "d_blank")]
     podcast: Option<String>,
-    #[serde(default = "d_zero", deserialize_with = "de_optional_string_or_number")]
-    feedID: Option<u64>,
-    #[serde(default = "d_blank")]
-    guid: Option<String>,
-    #[serde(default = "d_blank")]
-    url: Option<String>,
     #[serde(default = "d_blank")]
     episode: Option<String>,
-    #[serde(default = "d_zero", deserialize_with = "de_optional_string_or_number")]
-    itemID: Option<u64>,
-    #[serde(default = "d_blank")]
-    episode_guid: Option<String>,
-    #[serde(default = "d_blank")]
-    time: Option<String>,
-    #[serde(default = "d_zero", deserialize_with = "de_optional_string_or_number")]
-    ts: Option<u64>,
     #[serde(default = "d_zero", deserialize_with = "de_optional_string_or_number")]
     value_msat: Option<u64>,
     #[serde(default = "d_zero", deserialize_with = "de_optional_string_or_number")]

--- a/webroot/script/helipad.js
+++ b/webroot/script/helipad.js
@@ -522,6 +522,9 @@ $(document).ready(function () {
                 </table>
               </div>
               <div class="modal-footer">
+                <div class="flex-fill">
+                    <a id="download-tlv" href="#" target="_blank">Download TLV</a>
+                </div>
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
               </div>
             </div>
@@ -543,11 +546,20 @@ $(document).ready(function () {
                 const boost = result[0];
                 let tlv = null;
 
+                $('#download-tlv')
+                    .prop('href', 'data:application/json;charset=utf-8,' + encodeURIComponent(boost.tlv))
+                    .prop('download', `tlv-${msgid}.json`)
+
                 try {
                     tlv = JSON.parse(boost.tlv);
                 }
                 catch (e) {
-                    return $table.html('Unable to parse TLV');
+                    $table.empty()
+                    $table.append('<tr><td colspan="2">Unable to parse TLV</td></tr>')
+                    $table.append(
+                        $('<tr>').append($('<th>').text('tlv')).append($('<td>').text(boost.tlv))
+                    )
+                    return
                 }
 
                 $table.empty().append(


### PR DESCRIPTION
* Removes fields from RawBoost that are not actually used by Helipad
* Include payments with invalid or missing actions into the Streams tab 
* Adds a Download TLV link to the Boost Info modal
* Show the TLV itself if the Boost Info modal can't parse it

![image](https://github.com/Podcastindex-org/helipad/assets/16781/7bfb4302-f9c7-407a-8bdc-86a33529659b)


Resolves #71