### PR TITLE
Add podcast filter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,8 @@ async fn main() {
                 .route("/sent", get(handler::api_v1_sent))
                 .route("/index", get(handler::api_v1_index))
                 .route("/sent_index", get(handler::api_v1_sent_index))
+                .route("/podcasts", get(handler::api_v1_podcasts))
+                .route("/sent_podcasts", get(handler::api_v1_sent_podcasts))
 
                 // allow all origins to GET from public api
                 .route_layer(CorsLayer::new().allow_methods([Method::GET]).allow_origin(Any))

--- a/webroot/html/home.html
+++ b/webroot/html/home.html
@@ -36,15 +36,22 @@
         <div class="rightHeader">
             <div class="balanceDisplay">
             </div>
-            <span class="csv">
+            <span class="csv mr-1">
                 <a target="_blank" href="" title="Export as CSV">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
                         <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V9H3V2a1 1 0 0 1 1-1h5.5v2zM3 12v-2h2v2H3zm0 1h2v2H4a1 1 0 0 1-1-1v-1zm3 2v-2h3v2H6zm4 0v-2h3v1a1 1 0 0 1-1 1h-2zm3-3h-3v-2h3v2zm-7 0v-2h3v2H6z"/>
                     </svg>
                 </a>
             </span>
+            <span class="filter mr-1">
+                <a href="#" title="Filter">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
+                        <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2z"/>
+                    </svg>
+                </a>
+            </span>
             <span class="settings">
-                <a href="/settings" title="Settings" style="color: #ccc;">
+                <a href="/settings" title="Settings">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-gear" viewBox="0 0 16 16">
                       <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
                       <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z"/>
@@ -55,6 +62,15 @@
     </div>
     <div class="messaging">
         <div class="inbox_msg">
+            <div id="inbox-filters" style="display: flex; justify-content: space-between" class="d-none">
+                <div id="filter-podcasts" class="dropdown">
+                    <button class="btn btn-sm btn-outline-dark text-light dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" style="border: .2rem transparent;">
+                        Filter by podcast
+                    </button>
+                    <div class="dropdown-menu" style="font-size: .875rem;">
+                    </div>
+                </div>
+            </div>
             <div class="mesgs">
                 <div class="msg_history"></div>
             </div>

--- a/webroot/html/sent.html
+++ b/webroot/html/sent.html
@@ -36,15 +36,22 @@
         <div class="rightHeader">
             <div class="balanceDisplay">
             </div>
-            <span class="csv">
+            <span class="csv mr-1">
                 <a target="_blank" href="" title="Export as CSV">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
                         <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V9H3V2a1 1 0 0 1 1-1h5.5v2zM3 12v-2h2v2H3zm0 1h2v2H4a1 1 0 0 1-1-1v-1zm3 2v-2h3v2H6zm4 0v-2h3v1a1 1 0 0 1-1 1h-2zm3-3h-3v-2h3v2zm-7 0v-2h3v2H6z"/>
                     </svg>
                 </a>
             </span>
+            <span class="filter mr-1">
+                <a href="#" title="Filter">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
+                        <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2z"/>
+                    </svg>
+                </a>
+            </span>
             <span class="settings">
-                <a href="/settings" title="Settings" style="color: #ccc;">
+                <a href="/settings" title="Settings">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-gear" viewBox="0 0 16 16">
                       <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
                       <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z"/>
@@ -55,6 +62,15 @@
     </div>
     <div class="messaging">
         <div class="inbox_msg">
+            <div id="inbox-filters" style="display: flex; justify-content: space-between" class="d-none">
+                <div id="filter-podcasts" class="dropdown">
+                    <button class="btn btn-sm btn-outline-dark text-light dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" style="border: .2rem transparent;">
+                        Filter by podcast
+                    </button>
+                    <div class="dropdown-menu" style="font-size: .875rem;">
+                    </div>
+                </div>
+            </div>
             <div class="mesgs">
                 <div class="msg_history"></div>
             </div>

--- a/webroot/html/settings.html
+++ b/webroot/html/settings.html
@@ -57,64 +57,62 @@
                 </div>
             </div>
         </div>
-        <div class="inbox_msg" style="overflow-y: auto">
-            <div class="row">
-                <div class="col-12">
-                    <div class="tab-content m-4 text-white">
-                        <div class="tab-pane fade show active" id="general-content" role="tabpanel" aria-labelledby="general-tab">
-                            <div id="general-settings-div" hx-get="/settings/general" hx-trigger="intersect">
-                            </div>
+        <div class="inbox_msg">
+            <div style="height: 80%; overflow: auto">
+                <div class="tab-content m-4 text-white">
+                    <div class="tab-pane fade show active" id="general-content" role="tabpanel" aria-labelledby="general-tab">
+                        <div id="general-settings-div" hx-get="/settings/general" hx-trigger="intersect">
                         </div>
-                        <div class="tab-pane fade" id="numerology-content" role="tabpanel" aria-labelledby="numerology-tab">
-                            <button
-                                class="btn btn-md btn-primary pull-right"
-                                hx-get="/settings/numerology/add"
-                                hx-target="#modals-here"
-                                hx-trigger="click"
-                                data-bs-toggle="modal"
-                                data-bs-target="#modals-here"
-                                hx-on::after-request="$('#modals-here').modal()"
-                            >
-                                Add Numerology
-                            </button>
+                    </div>
+                    <div class="tab-pane fade" id="numerology-content" role="tabpanel" aria-labelledby="numerology-tab">
+                        <button
+                            class="btn btn-md btn-primary pull-right"
+                            hx-get="/settings/numerology/add"
+                            hx-target="#modals-here"
+                            hx-trigger="click"
+                            data-bs-toggle="modal"
+                            data-bs-target="#modals-here"
+                            hx-on::after-request="$('#modals-here').modal()"
+                        >
+                            Add Numerology
+                        </button>
 
-                            <b>Numerology</b>
-                            <div>Show emojis/play sounds when boosts matching the following amounts are received:</div>
+                        <b>Numerology</b>
+                        <div>Show emojis/play sounds when boosts matching the following amounts are received:</div>
 
-                            <table id="numerology" class="table table-dark table-hover text-white w-100 mt-4" hx-get="/settings/numerology" hx-trigger="intersect">
-                            </table>
+                        <table id="numerology" class="table table-dark table-hover text-white w-100 mt-4" hx-get="/settings/numerology" hx-trigger="intersect">
+                        </table>
 
-                            <button
-                                class="btn btn-md btn-danger"
-                                hx-get="/settings/numerology/reset"
-                                hx-target="#modals-here"
-                                hx-trigger="click"
-                                data-bs-toggle="modal"
-                                data-bs-target="#modals-here"
-                                hx-on::after-request="$('#modals-here').modal()"
-                            >
-                                Reset to default
-                            </button>
-                        </div>
-                        <div class="tab-pane fade" id="webhooks-content" role="tabpanel" aria-labelledby="webhooks-tab">
-                            <button
-                                class="btn btn-md btn-primary pull-right"
-                                hx-get="/settings/webhooks/add"
-                                hx-target="#modals-here"
-                                hx-trigger="click"
-                                data-bs-toggle="modal"
-                                data-bs-target="#modals-here"
-                                hx-on::after-request="$('#modals-here').modal()"
-                            >
-                                Add Webhook
-                            </button>
+                        <button
+                            class="btn btn-md btn-danger"
+                            hx-get="/settings/numerology/reset"
+                            hx-target="#modals-here"
+                            hx-trigger="click"
+                            data-bs-toggle="modal"
+                            data-bs-target="#modals-here"
+                            hx-on::after-request="$('#modals-here').modal()"
+                        >
+                            Reset to default
+                        </button>
+                    </div>
+                    <div class="tab-pane fade" id="webhooks-content" role="tabpanel" aria-labelledby="webhooks-tab">
+                        <button
+                            class="btn btn-md btn-primary pull-right"
+                            hx-get="/settings/webhooks/add"
+                            hx-target="#modals-here"
+                            hx-trigger="click"
+                            data-bs-toggle="modal"
+                            data-bs-target="#modals-here"
+                            hx-on::after-request="$('#modals-here').modal()"
+                        >
+                            Add Webhook
+                        </button>
 
-                            <b>Webhooks</b>
-                            <div>Send HTTP POSTs to the following URLs when boosts are received:</div>
+                        <b>Webhooks</b>
+                        <div>Send HTTP POSTs to the following URLs when boosts are received:</div>
 
-                            <table id="webhooks" class="table table-dark table-hover text-white w-100 mt-4" hx-get="/settings/webhooks" hx-trigger="intersect">
-                            </table>
-                        </div>
+                        <table id="webhooks" class="table table-dark table-hover text-white w-100 mt-4" hx-get="/settings/webhooks" hx-trigger="intersect">
+                        </table>
                     </div>
                 </div>
             </div>

--- a/webroot/html/streams.html
+++ b/webroot/html/streams.html
@@ -36,15 +36,22 @@
         <div class="rightHeader">
             <div class="balanceDisplay">
             </div>
-            <span class="csv">
+            <span class="csv mr-1">
                 <a target="_blank" href="" title="Export as CSV">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" class="bi bi-file-earmark-spreadsheet" viewBox="0 0 16 16">
                         <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V9H3V2a1 1 0 0 1 1-1h5.5v2zM3 12v-2h2v2H3zm0 1h2v2H4a1 1 0 0 1-1-1v-1zm3 2v-2h3v2H6zm4 0v-2h3v1a1 1 0 0 1-1 1h-2zm3-3h-3v-2h3v2zm-7 0v-2h3v2H6z"/>
                     </svg>
                 </a>
             </span>
+            <span class="filter mr-1">
+                <a href="#" title="Filter">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-funnel" viewBox="0 0 16 16">
+                        <path d="M1.5 1.5A.5.5 0 0 1 2 1h12a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.128.334L10 8.692V13.5a.5.5 0 0 1-.342.474l-3 1A.5.5 0 0 1 6 14.5V8.692L1.628 3.834A.5.5 0 0 1 1.5 3.5zm1 .5v1.308l4.372 4.858A.5.5 0 0 1 7 8.5v5.306l2-.666V8.5a.5.5 0 0 1 .128-.334L13.5 3.308V2z"/>
+                    </svg>
+                </a>
+            </span>
             <span class="settings">
-                <a href="/settings" title="Settings" style="color: #ccc;">
+                <a href="/settings" title="Settings">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-gear" viewBox="0 0 16 16">
                       <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z"/>
                       <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115l.094-.319z"/>
@@ -55,7 +62,15 @@
     </div>
     <div class="messaging">
         <div class="inbox_msg">
-
+            <div id="inbox-filters" style="display: flex; justify-content: space-between" class="d-none">
+                <div id="filter-podcasts" class="dropdown">
+                    <button class="btn btn-sm btn-outline-dark text-light dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false" style="border: .2rem transparent;">
+                        Filter by podcast
+                    </button>
+                    <div class="dropdown-menu" style="font-size: .875rem;">
+                    </div>
+                </div>
+            </div>
             <div class="mesgs">
                 <div class="msg_history"></div>
             </div>

--- a/webroot/script/helipad.js
+++ b/webroot/script/helipad.js
@@ -888,6 +888,7 @@ $(document).ready(function () {
         if (filters.podcast) {
             $('#filter-podcasts button').text(`Filtering by `).append($('<b>').text(filters.podcast));
             $('#inbox-filters').removeClass('d-none')
+            $('.filter a').addClass('text-danger')
         }
 
         $('.filter a').click((ev) => {
@@ -916,9 +917,11 @@ $(document).ready(function () {
 
                 if (filters.podcast) {
                     $('#filter-podcasts button').text(`Filtering by `).append($('<b>').text(filters.podcast));
+                    $('.filter a').addClass('text-danger')
                 }
                 else {
                     $('#filter-podcasts button').text(`Filter by podcast`);
+                    $('.filter a').removeClass('text-danger')
                 }
 
                 inbox.empty();

--- a/webroot/script/helipad.js
+++ b/webroot/script/helipad.js
@@ -306,7 +306,7 @@ $(document).ready(function () {
                 if ($('div.outgoing_msg').length == 0 && $('div.nodata').length == 0) {
                     if (filters.podcast) {
                         inbox.prepend('<div class="nodata"><p>No data found that matches your current filters.</p>' +
-                            '<p>This screen will automatically refresh if new ' + config.pluralName + ' matching your filters are found.</p>' +
+                            '<p>This screen will automatically refresh when new ' + config.pluralName + ' matching your filters are found.</p>' +
                             '<div class="lds-dual-ring"></div> Looking for ' + config.pluralName + ': <span class="invindex">' + currentInvoiceIndex + '</span>' +
                             '</div>');
                     }

--- a/webroot/style/default.css
+++ b/webroot/style/default.css
@@ -266,6 +266,22 @@ img {
     margin-bottom: 8px;
 }
 
+.titleBar a:hover {
+    color: white;
+    text-decoration: none;
+}
+.titleBar a {
+    color: #ccc;
+}
+
+.csv a {
+    color: var(--blue);
+}
+
+.csv a:hover {
+    color: #66b0ff;
+}
+
 h5.titleHeader {
     color: floralwhite;
     display: inline;
@@ -341,12 +357,6 @@ div.piIcon {
     padding-right:2px;
     float:right;
 }
-span.csv {
-    padding-right:8px;
-}
-span.csv a {
-    text-decoration: none;
-}
 div.nodata span.invindex {
     color: orange;
 }
@@ -369,23 +379,10 @@ ul.navButtons li.active,
 ul.navButtons li a.active {
     border-bottom: 2px solid red
 }
-ul.navButtons li:hover a {
-    color: white;
-    text-decoration: none;
-}
-ul.navButtons li a {
-    color: #ccc;
-}
 ul.navButtons li.active a,
 ul.navButtons li a[aria-selected="true"] {
     color: white;
     font-weight: bold;
-}
-.settings a {
-    color: #ccc;
-}
-.settings a:hover {
-    opacity: .6;
 }
 .rightHeader {
     display: flex;


### PR DESCRIPTION
Adds the ability to filter by a particular podcast (Resolves #74)

Adds a filter button to the top:
![image](https://github.com/user-attachments/assets/239da5af-ffeb-4fe6-b497-b577e35013d4)

Clicking on the filter button reveals the filter options:
![image](https://github.com/user-attachments/assets/e9e97aee-cda9-491f-a16c-b19dab3d48e3)

Clicking on Filter by podcast brings up a list of podcasts from the db:
![image](https://github.com/user-attachments/assets/b74d8588-fea5-4808-bd44-1c858696e068)

To-do:
* [x] Add code to Streams and Sent Boosts tabs
* [x] Add indicator to filter icon when filters are applied
* [x] Clean up code and remove comments
* [x] Fix CSS issues with settings page
* [x] Fix alignment issues with buttons
* [x] Test performance with a bunch of podcasts and boosts
