### PR TITLE
Add njump links to nostr references

### DIFF
--- a/webroot/script/helipad.js
+++ b/webroot/script/helipad.js
@@ -143,6 +143,9 @@ $(document).ready(function () {
                         boostPerson = `from ${element.sender}`;
                     }
 
+                    //Add njump links to nostr references
+                    boostMessage = boostMessage.replace(/(nostr:([\w\d]{63,}))/g, '<a href="https://njump.me/$2" target="_blank">$1</a>');
+
                     //Format the boost message
                     if (boostMessage.trim() != "") {
                         boostMessage = '' +


### PR DESCRIPTION
Fountain is now sending nostr references in boost messages. This PR adds links to njump.me for any nostr references it finds.

Resolves #97 