### PR TITLE
Show split name as part of wallet info

### DIFF
--- a/webroot/script/helipad.js
+++ b/webroot/script/helipad.js
@@ -165,7 +165,7 @@ $(document).ready(function () {
 
             let boostWalletInfo = '';
             if (settings.show_hosted_wallet_ids && boostCustomValue) {
-                boostWalletInfo = `<small>[Wallet #${escapeHTML(boostCustomValue)}]</small>`;
+                boostWalletInfo = `<small>[${escapeHTML(boostTlv.name ?? 'Wallet')} #${escapeHTML(boostCustomValue)}]</small>`;
             }
 
             //Show clock icon for automated boosts


### PR DESCRIPTION
Rather than showing Wallet \#1234, show Ericpp \#1234 in wallet info for boost

Related #129